### PR TITLE
Updated to slightly newer zookeeper dependency 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject avout "0.5.4"
+(defproject hellonico/avout "0.5.4"
   :description "Avout: Distributed State in Clojure"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [zookeeper-clj "0.9.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,7 @@
-(defproject avout "0.5.3"
+(defproject avout "0.5.4"
   :description "Avout: Distributed State in Clojure"
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [zookeeper-clj "0.9.1"]]
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 [zookeeper-clj "0.9.2"]
+                 [org.apache.zookeeper/zookeeper "3.3.2"]
+                 ]
   :dev-dependencies [[lein-clojars "0.7.0"]])


### PR DESCRIPTION
Would be great if I could revert back to using your repository.

The old dependencies were failing to connect properly to a new Zookeeper server.
