### PR TITLE
Make zk-atoms actually persist

### DIFF
--- a/src/avout/atoms/zk.clj
+++ b/src/avout/atoms/zk.clj
@@ -9,7 +9,7 @@
   StateContainer
 
   (initStateContainer [this]
-    (zk/create-all (.getClient client-handle) dataNode))
+    (zk/create-all (.getClient client-handle) dataNode :persistent? true))
 
   (destroyStateContainer [this]
     (zk/delete-all (.getClient client-handle) dataNode))


### PR DESCRIPTION
I spoke too soon before when I said this wasn't an issue. It turns out
that zk-atoms would persist as long as _some_ client was
connected, but otherwise they would disappear. Weirdly, this isn't a
problem with zk-refs.

This commit changes the way that zk-atoms are created in ZooKeeper by
adding `:persistent? true`.
